### PR TITLE
Use $(LLVM) instead of $(LD65) in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ $(OBJDIR)/%: $(OBJDIR)/%.o
 
 $(OBJDIR)/%.bin: $(OBJDIR)/src/%.o $(COMMON) src/%.ld 
 	@mkdir -p $(dir $@)
-	$(LD65)ld.lld \
+	$(LLVM)ld.lld \
 		-Map $(OBJDIR)/$*.map \
 		-T src/$*.ld \
 		-o $@ \


### PR DESCRIPTION
Before, the last linking step used the $(LD65) variable to find `ld.lld`, but that is part of `$(LLVM)`.  Making the `Makefile` configurable doesn't seem worth the effort because the invocation of `ld65` is so different from `ld.lld`.